### PR TITLE
fix(app): ripristino engine alla ripresa della scheda da mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const App = () => {
   const {
     startTransport,
     stopTransport,
+    restartEngine,
     engineStatus,
     transportStatus,
     analyser,
@@ -147,6 +148,21 @@ const App = () => {
     if (transportStatus.status !== "stopped") return;
     void startTransport();
   }, [autoStartEnabled, engineStatus, startTransport, transportStatus.status]);
+
+  // On mobile, the browser may suspend the page and interrupt the camera
+  // stream. When the tab becomes visible again, do a full engine restart so
+  // MediaPipe re-acquires the camera and the transport loop resumes.
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.hidden) return;
+      if (!autoStartEnabled) return;
+      if (transportStatus.status === "running") return;
+      if (engineStatus === "initializing") return;
+      restartEngine();
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [autoStartEnabled, engineStatus, restartEngine, transportStatus.status]);
 
   return (
     <main


### PR DESCRIPTION
## Problema

Su mobile, quando il browser sospende la scheda in background, la camera stream di MediaPipe viene interrotta. Al ritorno in primo piano il transport loop rimane in stato `error` o `stopped` e l'engine non si riavvia mai automaticamente.

Il meccanismo di auto-start esistente si attiva solo quando `transportStatus === "stopped"`, ma non copriva il caso `"error"`, né era progettato per gestire la sospensione del browser.

## Soluzione

Aggiunto un listener `visibilitychange` in `App.tsx` che, quando la scheda torna visibile:

1. Chiama `restartEngine()` (full reinit) → MediaPipe ri-acquisisce la camera
2. Una volta che `engineStatus` torna `"ready"`, l'auto-start esistente fa ripartire il transport

**Guardie per evitare restart indesiderati:**
- `autoStartEnabled === false` → l'utente ha fermato manualmente, non si riavvia
- `transportStatus === "running"` → engine già funzionante, niente da fare
- `engineStatus === "initializing"` → reinit già in corso, si evita il doppio avvio

## Test

Testare su mobile (iOS Safari / Chrome Android):
- [ ] Apri l'app, avvia l'engine con la camera
- [ ] Passa ad un'altra app o blocca lo schermo per qualche secondo
- [ ] Torna alla scheda → l'engine deve ripartire automaticamente
- [ ] Premi Stop manualmente, poi cambia scheda e torna → l'engine **non** deve ripartire

🤖 Generated with [Claude Code](https://claude.com/claude-code)