### PR TITLE
fix(app): rimuovi guardia stale e resize canvas alla ripresa da mobile

### DIFF
--- a/src/hooks/useSonificationEngine.ts
+++ b/src/hooks/useSonificationEngine.ts
@@ -72,9 +72,15 @@ export const useSonificationEngine = (
 
   useEffect(() => {
     const handleResize = () => resizeCanvasRefToContainer(imageOverlayRef);
+    // visibilitychange covers mobile tab resume where no resize event is fired.
+    const handleVisibilityChange = () => {
+      if (!document.hidden) resizeCanvasRefToContainer(imageOverlayRef);
+    };
     window.addEventListener("resize", handleResize);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
       window.removeEventListener("resize", handleResize);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [imageOverlayRef]);
 


### PR DESCRIPTION
## Problema

Il fix precedente (#61) non risolveva completamente il problema su mobile per due ragioni:

### 1. Guardia `transportStatus === "running"` errata

Su iOS/Android il browser **congela l'esecuzione JS** quando la scheda va in background. L'async iterator di MediaPipe non ha modo di fallire mentre la pagina è sospesa, quindi quando la scheda torna in primo piano `transportStatus` legge ancora `"running"` (stato stantio). La guardia scattava immediatamente e `restartEngine()` non veniva mai chiamato.

**Soluzione:** rimossa la guardia — `restartEngine()` è già progettato per gestire un transport in esecuzione (lo ferma prima di reinizializzare).

### 2. Canvas non ridimensionato al ritorno da sospensione

Il resize dei canvas ascoltava solo l'evento `resize` di `window`. Su mobile, tornare da una scheda sospesa **non genera un evento `resize`** se l'orientamento non è cambiato, lasciando i canvas con dimensioni errate.

**Soluzione:** aggiunto listener `visibilitychange` in `useSonificationEngine` che chiama `resizeCanvasRefToContainer` quando la scheda torna visibile.

## Test

- [ ] Apri l'app su mobile, avvia la camera
- [ ] Passa ad un'altra app o blocca lo schermo per qualche secondo
- [ ] Torna alla scheda → engine si riavvia automaticamente e canvas è ridimensionato correttamente
- [ ] Premi Stop manualmente, poi cambia scheda e torna → **non** deve ripartire

🤖 Generated with [Claude Code](https://claude.com/claude-code)